### PR TITLE
fix contributor covenant badge link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 # FRC Team4585 Husky Robotics
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](https://github.com/Team4585/.github/blob/main/CODE_OF_CONDUCT.md)
 
 Thanks for visiting!


### PR DESCRIPTION
fixes the contributor covenant badge link on the org home page